### PR TITLE
FUL-12472: Fixed broken bullet points in password change dialog

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=7C29C4CC-FB65-4B67-BEDC-9D46EB629ED7

--- a/jquery.password_field.sass
+++ b/jquery.password_field.sass
@@ -1,3 +1,6 @@
+@import "node_modules/@fortawesome/fontawesome-pro/scss/fontawesome.scss"
+@import "node_modules/@fortawesome/fontawesome-pro/scss/solid.scss"
+
 input.visibility-toggle
     padding-right: 40px
     &::-ms-reveal
@@ -56,8 +59,11 @@ ul.password-validity
 
 
     li:before
-        font: normal normal normal 14px/1 FontAwesome
-        content: "\f058"
+        @extend %fa-icon
+        @extend .fas
+        content: $fa-var-circle
+        font-size: 14px/1
+        font-weight: 900
         margin: 0 5px 0 -15px
 
     li.invalid:before
@@ -122,7 +128,7 @@ $strong-color: #1E9E73
         @media (min-width: 769px)
             position: absolute
             right: 0
-            
+
         @media (max-width: 768px)
             display: none
 

--- a/jquery.password_field.sass
+++ b/jquery.password_field.sass
@@ -1,5 +1,5 @@
-@import "node_modules/@fortawesome/fontawesome-pro/scss/fontawesome.scss"
-@import "node_modules/@fortawesome/fontawesome-pro/scss/solid.scss"
+@import "node_modules/@fortawesome/fontawesome-pro/scss/fontawesome"
+@import "node_modules/@fortawesome/fontawesome-pro/scss/solid"
 
 input.visibility-toggle
     padding-right: 40px
@@ -59,10 +59,10 @@ ul.password-validity
 
 
     li:before
-        @extend %fa-icon
+        @include fa-icon
         @extend .fas
-        content: $fa-var-circle
-        font-size: 14px/1
+        content: fa-content($fa-var-circle)
+        font-size: 14px
         font-weight: 900
         margin: 0 5px 0 -15px
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-password-field",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "JQuery Plugin to customize password field",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/beekpr/jquery-password-field/issues"
   },
   "homepage": "https://github.com/beekpr/jquery-password-field#readme",
+  "dependencies": {
+    "@fortawesome/fontawesome-pro": "^5.2.0"
+  },
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-bower-task": "^0.4.0",


### PR DESCRIPTION
The issue was caused by update of font awesome that changed font name and some other values that were hardcoded in this repo. After my changes FA mixins and vars are used instead so it doesn't happen in the future.